### PR TITLE
Update PermissionEditor component

### DIFF
--- a/components/PermissionEditor.vue
+++ b/components/PermissionEditor.vue
@@ -1,0 +1,157 @@
+<template>
+  <a-table :columns="menuColumns" :data-source="flatMenuData" size="small" bordered :pagination="false" :scroll="{ y: '60vh' }">
+    <template #bodyCell="{ column, record }">
+      <template v-if="column.dataIndex === 'permission' && record.permissionBit !== undefined">
+        <a-radio-group size="small" option-type="button" button-style="solid" :value="getPermission(record.key, record.permissionBit)" @change="e => setPermission(record.key, record.permissionBit, e.target.value)">
+          <a-radio :value="0">Ẩn</a-radio>
+          <a-radio :value="1">Xem</a-radio>
+          <a-radio :value="2">Sửa</a-radio>
+        </a-radio-group>
+      </template>
+      <template v-else-if="column.dataIndex === 'title'">
+        <div :style="{ paddingLeft: (record.level * 16) + 'px' }" class="flex items-center">
+          <span v-if="record.children" class="mr-1">📁</span>
+          <span v-else class="mr-1">📄</span>
+          {{ record.title }}
+        </div>
+      </template>
+    </template>
+  </a-table>
+</template>
+
+<script setup>
+const { RestApi } = useApi()
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const flatData = ref([])
+const flatMenuData = ref([])
+const menuPermissions = reactive({})
+
+// Tải dữ liệu menu
+const fetchData = async () => {
+  try {
+    const { data } = await RestApi.menu.list()
+    if (data.value?.status === 'success') {
+      flatData.value = data.value.data // API trả về mảng trực tiếp
+      flatMenuData.value = buildMenuWithLevel(flatData.value)
+      initMenuPermissions(flatData.value, props.modelValue)
+    }
+  } catch (e) {
+    message.error('Lỗi khi tải menu')
+  }
+}
+
+function buildMenuWithLevel(data, parentId = null, level = 0) {
+  const result = []
+  data
+    .filter(item => item.parent_Id === parentId)
+    .forEach(item => {
+      const children = buildMenuWithLevel(data, item.id, level + 1)
+      result.push({
+        ...item,
+        level,
+        children: children.length > 0 ? children : undefined
+      })
+    })
+  return result
+}
+
+function normalizeInputPermissions(menuData, inputPermissions) {
+  const validParentKeys = new Set(menuData.filter(d => d.parent_Id === null).map(d => d.key))
+  validParentKeys.add('menu')
+  return inputPermissions.filter(item =>
+    validParentKeys.has(item.key) && typeof item.permissionValue === 'number'
+  )
+}
+
+function initMenuPermissions(menuData, serverPerms) {
+  const normalizedPermissions = normalizeInputPermissions(menuData, serverPerms)
+  Object.keys(menuPermissions).forEach(key => delete menuPermissions[key])
+  const serverPermsMap = {}
+  normalizedPermissions.forEach(item => {
+    serverPermsMap[item.key] = item.permissionValue
+  })
+  menuPermissions.menu = serverPermsMap.menu || 0
+  const parentKeys = menuData.filter(d => d.parent_Id === null).map(d => d.key)
+  parentKeys.forEach(key => {
+    menuPermissions[key] = serverPermsMap[key] || 0
+  })
+}
+
+watch(() => props.modelValue, (newVal) => {
+  if (flatData.value.length > 0) {
+    initMenuPermissions(flatData.value, newVal)
+  }
+}, { deep: true })
+
+const menuColumns = [
+  { title: 'Tên Menu', dataIndex: 'title' },
+  { title: 'Quyền', dataIndex: 'permission' },
+]
+
+const isTopLevel = (key) => flatMenuData.value.some(m => m.key === key)
+const findParentKey = (childKey) => {
+  const child = flatData.value.find(item => item.key === childKey)
+  if (!child) return null
+  const parent = flatData.value.find(item => item.id === child.parent_Id)
+  return parent?.key
+}
+
+const getPermission = (key, permissionBit) => {
+  const isParent = isTopLevel(key)
+  const parentKey = isParent ? 'menu' : findParentKey(key)
+  return ((menuPermissions[parentKey] ?? 0) >> permissionBit) & 0b11
+}
+
+const setPermission = (key, permissionBit, val) => {
+  const isParent = isTopLevel(key)
+  const parentKey = isParent ? 'menu' : findParentKey(key)
+  const current = menuPermissions[parentKey] ?? 0
+  const cleared = current & ~(0b11 << permissionBit)
+  const updated = cleared | (val << permissionBit)
+  menuPermissions[parentKey] = updated
+  emit('update:modelValue', permissionList.value)
+}
+
+const permissionList = computed(() => {
+  const allParentKeys = flatData.value.filter(item => item.parent_Id === null).map(item => item.key)
+  const result = []
+  result.push({
+    key: 'menu',
+    permissionValue: menuPermissions.menu || 0
+  })
+  allParentKeys.forEach(key => {
+    result.push({
+      key,
+      permissionValue: menuPermissions[key] || 0
+    })
+  })
+  return result
+})
+
+fetchData()
+</script>
+
+<style scoped>
+.table-container {
+  height: 70vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.table-container :deep(.ant-table) {
+  flex: 1;
+  overflow: auto;
+}
+.table-container :deep(.ant-table-container) {
+  height: 100%;
+}
+</style>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -3,6 +3,9 @@ let ENDPOINTS = {
   S3: "/api/presigned_url",
   USER_PASSWORD: "/api/users/password",
   MENU: "/api/menus",
+  ROLE_GROUP: "/api/role-groups",
+  ROLE_GROUP_DETAIL: "/api/role-groups/detail",
+  USER_PERMISSION: "",
 };
 import { useUserStore } from "~~/stores/userStore";
 class Request {
@@ -99,11 +102,33 @@ class Menu {
     return await this.request.delete(ENDPOINTS.MENU, data);
   }
 }
+
+class RoleGroup {
+  constructor(request) {
+    this.request = request;
+  }
+  async list(data) {
+    return await this.request.get(ENDPOINTS.ROLE_GROUP, data);
+  }
+  async detail(data) {
+    return await this.request.get(ENDPOINTS.ROLE_GROUP_DETAIL, data);
+  }
+  async create(data) {
+    return await this.request.post(ENDPOINTS.ROLE_GROUP, data);
+  }
+  async update(data) {
+    return await this.request.put(ENDPOINTS.ROLE_GROUP, data);
+  }
+  async delete(data) {
+    return await this.request.delete(ENDPOINTS.ROLE_GROUP, data);
+  }
+}
 class RestApi {
   constructor() {
     this.request = new Request();
     this.user = new User(this.request);
     this.menu = new Menu(this.request);
+    this.roles = new RoleGroup(this.request);
   }
   async get_url_upload(acl, content_encoding, content_type, key, platform) {
     let data = { acl, content_encoding, content_type, key, platform };
@@ -173,6 +198,9 @@ class User {
   }
   async change_pasword(data) {
     return await this.request.put(ENDPOINTS.USER_PASSWORD, data);
+  }
+  async permission(data) {
+    return await this.request.get(ENDPOINTS.USER_PERMISSION, data);
   }
 }
 

--- a/composables/usePermissions.js
+++ b/composables/usePermissions.js
@@ -1,0 +1,46 @@
+import { useSettingStore } from "~/stores/settingStore";
+import useApi from "~/composables/useApi";
+
+export const usePermissions = () => {
+  const { RestApi } = useApi();
+  const settingStore = useSettingStore();
+  const DEFAULT_PERMISSIONS = [
+    {
+      key: "menu",
+      permissionValue: 42,
+    },
+    {
+      key: "menu-plvuxq63o0",
+      permissionValue: 0,
+    },
+    {
+      key: "menu-c8u2jgnoto",
+      permissionValue: 2796202,
+    },
+    {
+      key: "menu-f5fh5fri05",
+      permissionValue: 170,
+    },
+  ];
+
+  const loadPermissions = async () => {
+    try {
+      const { data: res } = await RestApi.user.permission();
+      const permission = res?.value?.data?.permission;
+      if (permission) {
+        settingStore.setPermissions(permission);
+      } else {
+        console.warn("Không có dữ liệu permission trả về");
+      }
+    } catch (error) {
+      console.error("Lỗi loadPermissions:", error);
+    }
+  };
+
+  const setPermissions = (perms) => {
+    settingStore.setPermissions(perms || DEFAULT_PERMISSIONS);
+    // settingStore.setPermissions(DEFAULT_PERMISSIONS);
+  };
+
+  return { loadPermissions, setPermissions };
+};

--- a/pages/role-group.vue
+++ b/pages/role-group.vue
@@ -12,8 +12,8 @@
           <template v-if="column.key === 'stt'">
             {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
           </template>
-          <template v-if="column.key === 'mota'">
-            <span v-if="record.mota">{{ record.mota }}</span>
+          <template v-if="column.key === 'description'">
+            <span v-if="record.description">{{ record.description }}</span>
             <span v-else class="text-gray-400">Trống</span>
           </template>
           <template v-if="column.key === 'action'">
@@ -41,12 +41,12 @@
     <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa Nhóm quyền' : 'Thêm mới Nhóm quyền'" @cancel="handleCancel" :width="modalWidth" :bodyStyle="{ maxHeight: '70vh', overflowY: 'auto' }">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
         <a-form ref="formRef" :model="formState" layout="vertical">
-          <a-form-item label="Tên Nhóm quyền" name="ten" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }" :rules="rules.ten">
-            <a-input v-model:value="formState.ten" placeholder="Nhập tên Nhóm quyền" :maxlength="200" show-count />
+          <a-form-item label="Tên Nhóm quyền" name="name" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }" :rules="rules.name">
+            <a-input v-model:value="formState.name" placeholder="Nhập tên Nhóm quyền" :maxlength="200" show-count />
           </a-form-item>
 
-          <a-form-item label="Mô tả" name="mota" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
-            <a-textarea v-model:value="formState.mota" :rows="4" placeholder="Nhập mô tả (nếu có)" :maxlength="200" show-count />
+          <a-form-item label="Mô tả" name="description" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
+            <a-textarea v-model:value="formState.description" :rows="4" placeholder="Nhập mô tả (nếu có)" :maxlength="200" show-count />
           </a-form-item>
         </a-form>
         <PermissionEditor v-model="formState.permission" />
@@ -91,20 +91,20 @@ const pagination = reactive({
 
 const columns = [
   { title: 'STT', key: 'stt', width: 50, align: 'center' },
-  { title: 'Tên Nhóm quyền', dataIndex: 'ten', key: 'ten', ellipsis: true },
-  { title: 'Mô tả', dataIndex: 'mota', key: 'mota', ellipsis: true },
+  { title: 'Tên Nhóm quyền', dataIndex: 'name', key: 'name', ellipsis: true },
+  { title: 'Mô tả', dataIndex: 'description', key: 'description', ellipsis: true },
   { title: 'Thao tác', key: 'action', width: 80, align: 'center', fixed: 'right' }
 ];
 
 const formState = reactive({
   id: null,
-  ten: '',
-  mota: '',
+  name: '',
+  description: '',
   permission: []
 });
 
 const rules = reactive({
-  ten: [
+  name: [
     { required: true, message: 'Vui lòng nhập tên Nhóm quyền', trigger: 'blur' },
     { min: 2, message: 'Tên phải có ít nhất 2 ký tự', trigger: 'blur' }
   ]
@@ -144,7 +144,7 @@ const handleSearch = async () => {
 
 const showModal = async () => {
   isEdit.value = false;
-  Object.assign(formState, { id: null, ten: '', mota: '', permission: [] });
+  Object.assign(formState, { id: null, name: '', description: '', permission: [] });
   visible.value = true;
 };
 

--- a/pages/role-group.vue
+++ b/pages/role-group.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm Nhóm quyền..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <ClientOnly class="overflow-x-auto">
@@ -19,13 +19,13 @@
           <template v-if="column.key === 'action'">
             <div class="flex justify-center">
               <div class="md:flex space-x-2">
-                <a-button type="link" size="small" @click="editItem(record.id)" :disabled="!settingStore.currentPermission">
+                <a-button type="link" size="small" @click="editItem(record.id)" :disabled="settingStore.currentPermission">
                   <template #icon>
                     <EditOutlined />
                   </template>
                 </a-button>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
-                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
+                  <a-button type="link" danger size="small" :disabled="settingStore.currentPermission">
                     <template #icon>
                       <DeleteOutlined />
                     </template>

--- a/pages/role-group.vue
+++ b/pages/role-group.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="p-2 md:p-4 bg-white min-h-full">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
+      <a-input-search v-model:value="searchText" placeholder="Tìm kiếm Nhóm quyền..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
+      <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
+    </div>
+
+    <ClientOnly class="overflow-x-auto">
+      <a-table :columns="columns" :data-source="dataSource" :pagination="pagination" :loading="loading" :scroll="{ x: '800' }" @change="handleTableChange" bordered size="small">
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">
+            {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
+          </template>
+          <template v-if="column.key === 'mota'">
+            <span v-if="record.mota">{{ record.mota }}</span>
+            <span v-else class="text-gray-400">Trống</span>
+          </template>
+          <template v-if="column.key === 'action'">
+            <div class="flex justify-center">
+              <div class="md:flex space-x-2">
+                <a-button type="link" size="small" @click="editItem(record.id)" :disabled="!settingStore.currentPermission">
+                  <template #icon>
+                    <EditOutlined />
+                  </template>
+                </a-button>
+                <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
+                    <template #icon>
+                      <DeleteOutlined />
+                    </template>
+                  </a-button>
+                </a-popconfirm>
+              </div>
+            </div>
+          </template>
+        </template>
+      </a-table>
+    </ClientOnly>
+
+    <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa Nhóm quyền' : 'Thêm mới Nhóm quyền'" @cancel="handleCancel" :width="modalWidth" :bodyStyle="{ maxHeight: '70vh', overflowY: 'auto' }">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <a-form ref="formRef" :model="formState" layout="vertical">
+          <a-form-item label="Tên Nhóm quyền" name="ten" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }" :rules="rules.ten">
+            <a-input v-model:value="formState.ten" placeholder="Nhập tên Nhóm quyền" :maxlength="200" show-count />
+          </a-form-item>
+
+          <a-form-item label="Mô tả" name="mota" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
+            <a-textarea v-model:value="formState.mota" :rows="4" placeholder="Nhập mô tả (nếu có)" :maxlength="200" show-count />
+          </a-form-item>
+        </a-form>
+        <PermissionEditor v-model="formState.permission" />
+      </div>
+
+      <template #footer>
+        <div class="flex justify-end space-x-2">
+          <a-button @click="handleCancel">Hủy</a-button>
+          <a-button type="primary" @click="handleOk" :loading="confirmLoading">
+            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+          </a-button>
+        </div>
+      </template>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+const settingStore = useSettingStore();
+const { loadPermissions } = usePermissions();
+import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
+const { RestApi } = useApi();
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isMobile = breakpoints.smaller('md');
+const modalWidth = computed(() => (isMobile.value ? '95vw' : 1000));
+const searchText = ref('');
+const loading = ref(false);
+const visible = ref(false);
+const confirmLoading = ref(false);
+const isEdit = ref(false);
+const formRef = ref();
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['1', '10', '20', '50'],
+  showTotal: (total) => `Tổng ${total} bản ghi`
+});
+
+const columns = [
+  { title: 'STT', key: 'stt', width: 50, align: 'center' },
+  { title: 'Tên Nhóm quyền', dataIndex: 'ten', key: 'ten', ellipsis: true },
+  { title: 'Mô tả', dataIndex: 'mota', key: 'mota', ellipsis: true },
+  { title: 'Thao tác', key: 'action', width: 80, align: 'center', fixed: 'right' }
+];
+
+const formState = reactive({
+  id: null,
+  ten: '',
+  mota: '',
+  permission: []
+});
+
+const rules = reactive({
+  ten: [
+    { required: true, message: 'Vui lòng nhập tên Nhóm quyền', trigger: 'blur' },
+    { min: 2, message: 'Tên phải có ít nhất 2 ký tự', trigger: 'blur' }
+  ]
+});
+
+const param = ref({ PageIndex: 1, PageSize: 10, search: '' });
+const dataSource = ref([]);
+
+const fetchData = async (param) => {
+  try {
+    loading.value = true;
+    const { data } = await RestApi.roles.list({ params: param });
+    if (data.value?.status === 'success') {
+      dataSource.value = data.value.data.items || [];
+      pagination.total = data.value.data.totalrecord;
+    }
+  } catch (err) {
+    message.error('Không thể tải dữ liệu');
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleTableChange = async (pag) => {
+  pagination.current = pag.current;
+  pagination.pageSize = pag.pageSize;
+  param.value.PageIndex = pag.current;
+  param.value.PageSize = pag.pageSize;
+  await fetchData({ ...param.value });
+};
+
+const handleSearch = async () => {
+  param.value.search = searchText.value;
+  pagination.current = 1;
+  await fetchData({ ...param.value });
+};
+
+const showModal = async () => {
+  isEdit.value = false;
+  Object.assign(formState, { id: null, ten: '', mota: '', permission: [] });
+  visible.value = true;
+};
+
+const editItem = async (id) => {
+  isEdit.value = true;
+  try {
+    const { data } = await RestApi.roles.detail({ params: { id } });
+    if (data.value?.status === 'success') {
+      Object.assign(formState, data.value.data);
+      visible.value = true;
+    }
+  } catch (err) {
+    message.error('Không thể lấy dữ liệu chi tiết');
+  }
+};
+
+const handleOk = async () => {
+  try {
+    await formRef.value.validate();
+    confirmLoading.value = true;
+
+    let res;
+    if (isEdit.value) {
+      res = await RestApi.roles.update({ body: { ...formState } });
+    } else {
+      const payload = { ...formState };
+      delete payload.id;
+      res = await RestApi.roles.create({ body: payload });
+    }
+
+    if (res.data.value?.status === 'success') {
+      message.success(res.data.value?.message || 'Thành công');
+      await fetchData({ ...param.value });
+      visible.value = false;
+      formRef.value.resetFields();
+    } else {
+      throw new Error(res.error?.value?.data?.message || 'Lỗi không xác định');
+    }
+  } catch (err) {
+    message.error(err.message || 'Lỗi khi lưu thông tin');
+  } finally {
+    await loadPermissions();
+    confirmLoading.value = false;
+  }
+};
+
+const handleCancel = () => {
+  formRef.value.resetFields();
+  visible.value = false;
+};
+
+const deleteItem = async (id) => {
+  try {
+    const { data } = await RestApi.roles.delete({ params: { id } });
+    if (data.value?.status === 'success') {
+      message.success(data.value?.message || 'Đã xóa');
+      await fetchData({ ...param.value });
+    } else {
+      message.error(data.value?.message || 'Không thể xóa');
+    }
+  } catch (err) {
+    message.error('Lỗi khi xóa');
+  }
+};
+
+const resetForm = async () => {
+  if (formRef.value) formRef.value.resetFields();
+  param.value = { PageIndex: 1, PageSize: 10, search: '' };
+  pagination.current = 1;
+  pagination.pageSize = 10;
+  await fetchData({ ...param.value });
+};
+
+await fetchData({ ...param.value });
+</script>
+<style scoped>
+.custom-modal :deep(.ant-modal-body) {
+  padding: 16px 24px;
+}
+
+.custom-modal :deep(.ant-modal-content) {
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.custom-modal :deep(.ant-modal-header) {
+  flex-shrink: 0;
+}
+
+.custom-modal :deep(.ant-modal-footer) {
+  flex-shrink: 0;
+}
+</style>

--- a/stores/settingStore.js
+++ b/stores/settingStore.js
@@ -27,6 +27,14 @@ export const useSettingStore = defineStore(
           icon: "ant-design:unordered-list-outlined",
           children: [],
         },
+        {
+          title: "Role Group",
+          key: "role_group",
+          url: "/role-group",
+          bitIndex: 4,
+          icon: "ant-design:team-outlined",
+          children: [],
+        },
         // {
         //   title: "Quản Lý Danh Mục",
         //   key: "category_management",


### PR DESCRIPTION
## Summary
- implement table-based permission editor
- add permission loading composable and API hook

## Testing
- `yarn build` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_b_685d0d1de7f08331a25e3cff1bda17ce